### PR TITLE
feat(package): Move nsp check from prepare step to an optional script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "tape test/*.js | tap-spec",
     "lint": "eslint test/*.js app.js bin/*",
-    "prepare": "nsp check",
+    "prepare": "echo 'To confirm CVE compliance, run \"npm run security-check\"' ",
+    "security-check": "nsp check",
     "coverage": "nyc npm test",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "ci": "npm run lint && npm run coveralls",


### PR DESCRIPTION
* prepare will now output a message telling the user how to run nsp.

fixes #78