### PR TITLE
chore(release): Add a postbump lifecycle method to update the version…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,7 +855,7 @@
       "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.5",
         "minimist": "1.2.0",
@@ -1181,7 +1181,7 @@
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -2367,9 +2367,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -3018,7 +3018,7 @@
       "requires": {
         "chalk": "2.3.1",
         "git-repo-info": "1.4.1",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "openshift-config-loader": "0.4.0",
@@ -5084,7 +5084,7 @@
       "integrity": "sha512-/FMAxwvHTdXurj7OcsZ3uhMd8a6l2wvMhp8lyoh7L3JjByEFjmebezVVMl73VE11HW+i+k4K+svGFgSh192ZXQ==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.9.1"
+        "js-yaml": "3.10.0"
       }
     },
     "openshift-rest-client": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,16 @@
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "ci": "npm run lint && npm run coveralls",
     "dependencyCheck": "szero . --ci",
-    "release": "standard-version",
+    "release": "standard-version -a",
     "openshift": "nodeshift --strictSSL=false --nodeVersion=8.x",
     "postinstall": "license-reporter report && license-reporter save --xml licenses.xml",
     "start": "PORT=8080 node ./bin/www"
+  },
+  "standard-version": {
+    "scripts": {
+      "postbump": "node release.js",
+      "precommit": "git add .openshiftio/application.yaml"
+    }
   },
   "repository": {
     "type": "git",
@@ -43,6 +49,7 @@
     "eslint-plugin-promise": "~3.6.0",
     "eslint-plugin-react": "~7.7.0",
     "eslint-plugin-standard": "~3.0.1",
+    "js-yaml": "^3.10.0",
     "nodeshift": "~1.4.0",
     "nsp": "~3.2.1",
     "nyc": "~11.4.1",

--- a/release.js
+++ b/release.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// This file is run during the "postbump" lifecyle of standard-version
+// We need to be able to update the metadata.label.verion of the resource objects in the openshift template in the .openshiftio folder
+
+const packagejson = require('./package.json');
+
+const {promisify} = require('util');
+const fs = require('fs');
+const writeFile = promisify(fs.writeFile);
+const readFile = promisify(fs.readFile);
+const jsyaml = require('js-yaml');
+
+async function updateApplicationYaml () {
+  const applicationyaml = jsyaml.safeLoad(await readFile(`${__dirname}/.openshiftio/application.yaml`, {encoding: 'utf8'}));
+  // Loop through and update the metadata.label.version to the version from the package.json
+  applicationyaml.objects = applicationyaml.objects.map((object) => {
+    if (object.metadata && object.metadata.labels && object.metadata.labels.version) {
+      object.metadata.labels.version = packagejson.version;
+    }
+
+    return object;
+  });
+
+  // now write the file back out
+  await writeFile(`${__dirname}/.openshiftio/application.yaml`, jsyaml.safeDump(applicationyaml, {skipInvalid: true}), {encoding: 'utf8'});
+}
+
+updateApplicationYaml();


### PR DESCRIPTION
… numbers in the .openshiftio/application.yaml during the release process


I realized that during the release process, we also need to update the .openshiftio/application.yaml files version numbers.

This should take care of it.

the "postbump" lifecycle method will get the recently updated package.json version, update the metadata.labels.vesersion properties in that yaml file, then write it back out.

Then the "precommit"  stages the file and the "-a" flag on the "standard-release" script will make sure it is commited


I'll need to add this to the other boosters too